### PR TITLE
remove custom name to original name

### DIFF
--- a/short_circuit.gemspec
+++ b/short_circuit.gemspec
@@ -3,7 +3,7 @@ $:.push File.expand_path('../lib', __FILE__)
 require 'short_circuit/version'
 
 Gem::Specification.new do |s|
-  s.name        = 'short_circuit-cj'
+  s.name        = 'short_circuit'
   s.version     = ShortCircuit::VERSION
   s.authors     = ['Jim Pruetting']
   s.email       = ['jim@roboticmethod.com}']


### PR DESCRIPTION
#### why?

Because a gem name represents all the gem structure and convention and renamed only the gem_spec without renaming the structure and without changing the gem behavior doesn't feel right and also bundle project gets an error because of that.